### PR TITLE
Invalid URL parsing

### DIFF
--- a/nomad/engine/dbapi.py
+++ b/nomad/engine/dbapi.py
@@ -7,7 +7,7 @@ def path2dict(p, **renames):
     '''Convert urlparse result to dict
     '''
     result = {}
-    for k in 'hostname port path user password'.split():
+    for k in 'hostname port path username password'.split():
         value = getattr(p, k, None)
         if not value:
             continue
@@ -73,7 +73,7 @@ class Mysql(Connection):
     _conn = None
     def __init__(self, path):
         self.parameters = path2dict(path, hostname='host',
-                                    password='passwd', path='db')
+                                    password='passwd', path='db', username='user')
         import MySQLdb
         self.module = MySQLdb
         self.exc = MySQLdb.MySQLError
@@ -100,7 +100,7 @@ class Mysql(Connection):
 class Pgsql(Connection):
     _conn = None
     def __init__(self, path):
-        self.parameters = path2dict(path, hostname='host', path='database')
+        self.parameters = path2dict(path, hostname='host', path='database', username='user')
         import psycopg2
         self.module = psycopg2
         self.exc = psycopg2.Error


### PR DESCRIPTION
I just installed nomad in my development server. However it is unable to parse URL defined nomad.ini correctly

My URL: pgsql://my_username:my_password@host_name/database_name

When I run: nomad init I got an exception: no 'root' role defined. I expect that nomad should use "my_username" role instead.

I found a small bug in the code to parse the URL

{code}
def path2dict(p, **renames):
    '''Convert urlparse result to dict
'''
    result = {}
    for k in 'hostname port path user password'.split():
        value = getattr(p, k, None)
        if not value:
            continue
        if k == 'path':
            value = value.lstrip('/')
        result[renames.get(k, k)] = value
    return result
{code}

where p is produced by 
{code}
p = urlparse.urlparse("pgsql://my_username:my_password@host_name/database_name")
{code}

It looks like that you expect "user" is an attribute of p. However, it is not the case

{code}

> > > p = urlparse.urlparse("pgsql://my_username:my_password@host_name/database_name")
> > > p.username
> > > 'my_username'
> > > p.user
> > > Traceback (most recent call last):
> > >   File "<stdin>", line 1, in <module>
> > > AttributeError: 'ParseResult' object has no attribute 'user'
> > > 
> > > {code}
