### PR TITLE
Fix problem with trailing slash

### DIFF
--- a/nomad/repo.py
+++ b/nomad/repo.py
@@ -73,6 +73,8 @@ class Repository(object):
         return '<%s: %s>' % (type(self).__name__, self.path)
 
     def get(self, name):
+        if name.endswith('/'):
+            name = name[:-1]
         applied = name in self.appliednames
         return Migration(self, name, applied=applied)
 

--- a/tests/basic.t
+++ b/tests/basic.t
@@ -61,3 +61,12 @@ Natural sorting works::
   $ $NOMAD ls
   \x1b[32m3-fourth\x1b[0m (esc)
   \x1b[32m10-eleventh\x1b[0m (esc)
+
+No problems with trailing slash that can easily occur from autocomplete::
+
+  $ $NOMAD apply 3-fourth/
+  applying migration 3-fourth:
+    sql migration applied: up.sql
+  $ $NOMAD apply 3-fourth
+  \x1b[31mError: migration 3-fourth is already applied\x1b[0m (esc)
+  [1]


### PR DESCRIPTION
I applied some migrations and got this situation:

    $ nomad info
    <Repository: .>:
      10 applied
      -1 unapplied

Figured out it was caused by a trailing slash in migration names, like `nomad apply 3-fourth/`