### PR TITLE
Configuration updates, Jinja2 templating, PEP8 cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,6 @@ python:
   - "2.6"
   - "2.7"
   - "3.4"
+  - "3.5"
 install: "pip install -r requirements-dev.txt"
 script: "make test"

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,11 @@ Your directory tree thus will look like this::
       1-pre.py
       2-up.sql
       3-post.py
+    2011-11-13-third-migration/
+      migration.ini
+      1-pre.py
+      2-up.sql
+      3-post.sql.j2
 
 Nomad uses table called ``nomad`` to track what was applied already. It's just a
 list of applied migrations and dates when they were applied.
@@ -73,21 +78,31 @@ going to alter, or just to make it easier - on the latest available migration.
 Usage
 -----
 
-Idea is that you put your migrations in ``.sql`` files (name does not matter,
-and if there are few - they are executed in order), or in some executable
-file. It seems that first case is self-explanatory - you just put SQL commands
-you need to execute there and they will be executed.
+There are three types of migration files that ``nomad`` supports:
 
-In second case it's your job to do whatever is necessary to migrate your data,
-starting with establishing connection. To facilitate this, Nomad will pass
-everything you define in `Configuration`_ as environment variables, prefixed
-with ``NOMAD_``, so at least you will get ``NOMAD_ENGINE`` and ``NOMAD_URL`` -
-feel free to add more configuration there.
+1.  Plain SQL files with the extension ``.sql``. Just put SQL commands you need
+    to execute in the migration folder and they will be executed.
+2.  Executable files. All file extensions are supported as long as the file
+    is executable. These files must contain everything necessary to migrate
+    your data, including setting up a database connection. ``nomad`` will pass
+    all of the `Configuration`_ variables as environmental variables, prefixed
+    with their section.
+3.  Template files with the extension ``.j2``. These templates will be
+    passed through the Jinja2 templating library. You must install the
+    ``jinja2`` for this functionality. The entire `Configuration`_ is available
+    to the tempalte files as a single dictionary.
+
+
+Files inside of each migration folder are executed in lexographical order.
+
 
 Configuration
 -------------
 
-Nomad reads configuration from ``nomad.ini``, here is an example::
+Nomad reads database connection informatino from the ``[nomad]``
+section of the ``nomad.ini`` file.
+
+::
 
   [nomad]
   engine = sqla
@@ -103,16 +118,42 @@ Possible configuration options:
 - ``url`` (required) - URL to database, takes multiple options, see format below
 - ``path`` - path to migrations (default: directory with ``nomad.ini``)
 
-Each migration has its own ``migration.ini`` file, which at the moment has
+Each migration has its own ``migration.ini`` file, which, by default, has a
 single configuration option, ``nomad.dependencies``, defining which migration
 (or migrations) this one depends.
 
+You may add your own configuration variables to either the ``nomad.ini`` or
+``migration.ini`` files and they will be available in your jinja2 templates
+as a single dictionary and your executable files as environmental
+variables.
+
 Note that ini-files are parsed with extended interpolation (use it like
-``${var}`` or ``${section.var}``), few predefined variables are provided:
+``${var}`` or ``${section.var}``).
+
+A few predefined variables are provided to every migration:
 
 - ``confpath`` - path to ``nomad.ini``
 - ``confdir`` - path to directory, containing ``nomad.ini``
-- ``dir`` (migration only) - path to directory of migration
+- ``dir`` - path to directory of migration
+
+
+Example configuration:
+
++------------------+---------------------------+------------------------------+
+|   configration   |         executable        |          template            |
++==================+===========================+==============================+
+| ::               | ::                        | ::                           |
+|                  |                           |                              |
+|   [nomad]        |   NOMAD_ENGINE = sqla     |   nomad.engine = sqla        |
+|   engine = sqla  |   NOMAD_URL = someurl     |   nomad.url = someurl        |
+|   url = someurl  |                           |                              |
+|                  |   FOO_BAR = zeta          |   foo.bar = zeta             |
+|   [foo]          |                           |                              |
+|   bar = zeta     |   NOMAD_CONFPATH = path   |   nomad.confpath = path      |
+|                  |   NOMAD_CONFDIR = dir1    |   nomad.confdir = dir1       |
+|                  |   NOMAD_DIR = dir2        |   nomad.dir = dir2           |
++------------------+---------------------------+------------------------------+
+
 
 URL format
 ~~~~~~~~~~
@@ -151,7 +192,7 @@ normal format, i.e. ``dbtype://user:pass@host:port/dbname?options``.
 will do ``set ...`` before every migration. Note that if you do not supply
 anything there, nomad sets ``statement_timeout`` to 1000 ms and ``lock_timeout``
 to 500 ms by default.
-  
+
 Main ideas
 ----------
 
@@ -161,7 +202,7 @@ Main ideas
   track applied migrations and dependencies.
 - ``.sql`` is treated differently and executed against database, configured in
   ``nomad.ini``.
-- Only ``.sql`` and executable files (sorry, Windows! - though I am eager to
+- Only ``.sql``, ``.j2``, and executable files (sorry, Windows! - though I am eager to
   hear ideas how to support it) are executed. You can put READMEs, pieces of
   documentation, whatever you want alongside your migrations.
 - Name matters - everything is executed in order. Order is determined by using

--- a/README.rst
+++ b/README.rst
@@ -89,8 +89,24 @@ There are three types of migration files that ``nomad`` supports:
     with their section.
 3.  Template files with the extension ``.j2``. These templates will be
     passed through the Jinja2 templating library. You must install the
-    ``jinja2`` for this functionality. The entire `Configuration`_ is available
-    to the template files as a single dictionary.
+    ``jinja2`` library for this functionality. The entire `Configuration`_ is
+    available to the template files as a single dictionary. These could be
+    useful if you are distributing an application where the end user needs to
+    control some aspects of the migrations (ie. additional database users and
+    passwords, additonal database names, etc.).
+
+    ::
+
+      # nomad.ini
+      [db]
+      another_user = reader
+      another_pass = pass
+
+    ::
+
+      # migrations/0001-initial/up.sql.j2
+      CREATE ROLE {{ db.another_user }};
+      ALTER ROLE {{ db.another_user }} WITH NOSUPERUSER LOGIN PASSWORD '{{ db.another_pass }}' VALID UNTIL 'infinity';
 
 
 Files inside of each migration folder are executed in lexographical order.

--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ There are three types of migration files that ``nomad`` supports:
 3.  Template files with the extension ``.j2``. These templates will be
     passed through the Jinja2 templating library. You must install the
     ``jinja2`` for this functionality. The entire `Configuration`_ is available
-    to the tempalte files as a single dictionary.
+    to the template files as a single dictionary.
 
 
 Files inside of each migration folder are executed in lexographical order.
@@ -99,8 +99,8 @@ Files inside of each migration folder are executed in lexographical order.
 Configuration
 -------------
 
-Nomad reads database connection informatino from the ``[nomad]``
-section of the ``nomad.ini`` file.
+Nomad reads database connection information from the ``[nomad]`` section of the
+``nomad.ini`` file.
 
 ::
 

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -30,10 +30,11 @@ This will create directory with name ``2012-09-21-first`` and two files inside:
 ``migration.ini`` and ``up.sql``. Name of first file matters - it contains
 information about dependencies of a migration (which can be passed as ``-d``
 option to ``create`` command). Name of second file doesn't matter - any
-``*.sql`` or executable files (file with executable bit set) will be
-run. ``*.sql`` files are applied to database, while executable files (which can
-be your script to do something before or after migration, or even migration
-itself) are just executed.
+``*.sql``, ``*.j2``, or executable files (file with executable bit set) will be
+run. ``*.sql`` files are applied to database, ``*.j2`` files are applied to
+the database after being passed through the ``jinja2`` template system, and
+executable files (which can be your script to do something before or after
+migration, or even migration itself) are just executed.
 
 You can then list or apply migrations - just read help about them (``nomad help
 ls`` or ``nomad help apply``). Also, reading :doc:`test-basic` can be helpful as

--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -31,6 +31,7 @@ EXAMPLE_INI = '''
 def getconfig(func):
     if func.__name__.startswith('help') or func.__name__ in ('version',):
         return func
+
     def inner(*args, **kwargs):
         try:
             repo = Repository(kwargs['config'], kwargs['define'])
@@ -60,7 +61,7 @@ def init(**opts):
 
 @app.command(name='list', aliases=('ls',))
 def list_(all=('a', False, 'show all migrations (default: only non-applied)'),
-         **opts):
+          **opts):
     '''List migrations
     '''
     repo = opts['repo']

--- a/nomad/engine/dbapi.py
+++ b/nomad/engine/dbapi.py
@@ -64,6 +64,7 @@ class Sqlite(Connection):
 
 class Mysql(Connection):
     _conn = None
+
     def __init__(self, url):
         self.parameters = {'host':   unq(url.hostname),
                            'port':   url.port,
@@ -96,6 +97,7 @@ class Mysql(Connection):
 
 class Pgsql(Connection):
     _conn = None
+
     def __init__(self, url):
         self.parameters = {'host':     unq(url.hostname),
                            'port':     url.port,

--- a/nomad/repo.py
+++ b/nomad/repo.py
@@ -143,9 +143,11 @@ class Migration(object):
         return dict((k, dict(self.conf.items(k))) for k in self.conf.sections())
 
     def get_env(self):
-        return [{'{}_{}'.format(s.upper(), k.upper()) : v
-                 for k, v in self.conf.items(s) }
-                for s in self.conf.sections() ][0]
+        envs = {}
+        for k, d in self.get_config_dict().items():
+            for i, v in d.items():
+                envs['{}_{}'.format(k.upper(), i.upper())] = v
+        return envs
 
     @property
     def path(self):
@@ -180,7 +182,6 @@ class Migration(object):
                     loader=jinja2.FileSystemLoader(os.path.dirname(path))
                 )
                 j2_sql = j2_env.get_template(fn).render(self.get_config_dict())
-
                 self.repo.engine.query(clean_sql(j2_sql), escape=True)
                 print('  sql template migration applied: %s' % fn)
 

--- a/nomad/repo.py
+++ b/nomad/repo.py
@@ -98,7 +98,7 @@ class Repository(object):
 
     @cachedproperty
     def appliednames(self):
-        q = 'SELECT name FROM {} ORDER BY date'.format(
+        q = 'SELECT name FROM {0} ORDER BY date'.format(
             self.conf['nomad']['table']
         )
         return [x for (x, ) in self.engine.query(q)]
@@ -146,7 +146,7 @@ class Migration(object):
         envs = {}
         for k, d in self.get_config_dict().items():
             for i, v in d.items():
-                envs['{}_{}'.format(k.upper(), i.upper())] = v
+                envs['{0}_{1}'.format(k.upper(), i.upper())] = v
         return envs
 
     @property

--- a/nomad/repo.py
+++ b/nomad/repo.py
@@ -98,9 +98,7 @@ class Repository(object):
 
     @cachedproperty
     def appliednames(self):
-        q = 'SELECT name FROM {0} ORDER BY date'.format(
-            self.conf['nomad']['table']
-        )
+        q = 'SELECT name FROM %s ORDER BY date' % self.conf['nomad']['table']
         return [x for (x, ) in self.engine.query(q)]
 
     @property
@@ -146,7 +144,7 @@ class Migration(object):
         envs = {}
         for k, d in self.get_config_dict().items():
             for i, v in d.items():
-                envs['{0}_{1}'.format(k.upper(), i.upper())] = v
+                envs['%s_%s' % (k.upper(), i.upper())] = v
         return envs
 
     @property

--- a/nomad/repo.py
+++ b/nomad/repo.py
@@ -140,7 +140,7 @@ class Migration(object):
         raise TypeError('Migrations can be compared only with other migrations')
 
     def get_config_dict(self):
-        return { k: dict(self.conf.items(k)) for k in self.conf.sections() }
+        return dict((k, dict(self.conf.items(k))) for k in self.conf.sections())
 
     def get_env(self):
         return [{'{}_{}'.format(s.upper(), k.upper()) : v

--- a/nomad/repo.py
+++ b/nomad/repo.py
@@ -1,5 +1,6 @@
 from __future__ import print_function
-import os, os.path as op
+import os
+import os.path as op
 from datetime import datetime
 from configparser import ConfigParser, ExtendedInterpolation
 from subprocess import call
@@ -94,9 +95,10 @@ class Repository(object):
 
     @cachedproperty
     def appliednames(self):
-       return [x for (x, ) in
-               self.engine.query('SELECT name FROM %s ORDER BY date' %
-                                 self.conf['nomad']['table'])]
+        q = 'SELECT name FROM {} ORDER BY date'.format(
+            self.conf['nomad']['table']
+        )
+        return [x for (x, ) in self.engine.query(q)]
 
     @property
     def applied(self):

--- a/nomad/utils.py
+++ b/nomad/utils.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 import sys
 import re
-import os, os.path as op
+import os
+import os.path as op
 import shlex
 import imp
 import json
@@ -21,6 +22,7 @@ NUM_RE = re.compile('(\d+)')
 
 class NomadError(Exception):
     pass
+
 
 class NomadIniNotFound(Exception):
     pass
@@ -54,20 +56,20 @@ def shsplit(s):
 
 
 def humankey(fn):
-  '''Turn a string into a list of substrings and numbers.
+    '''Turn a string into a list of substrings and numbers.
 
-  This can be used as a key function for ``sorted``::
+    This can be used as a key function for ``sorted``::
 
-    >>> s = lambda *x: list(sorted(x, key=humankey))
-    >>> print(s('up-1', 'up-5', 'up-15', 'up-50'))
-    ['up-1', 'up-5', 'up-15', 'up-50']
-    >>> print(s('up-1.sql', 'up.sql', 'up1.sql'))
-    ['up.sql', 'up1.sql', 'up-1.sql']
-    >>> print(s('up.rb', 'up.py')) # check extension sorting
-    ['up.py', 'up.rb']
-  '''
-  fn, ext = os.path.splitext(fn)
-  return [int(s) if s.isdigit() else s for s in NUM_RE.split(fn)], ext
+        >>> s = lambda *x: list(sorted(x, key=humankey))
+        >>> print(s('up-1', 'up-5', 'up-15', 'up-50'))
+        ['up-1', 'up-5', 'up-15', 'up-50']
+        >>> print(s('up-1.sql', 'up.sql', 'up1.sql'))
+        ['up.sql', 'up1.sql', 'up-1.sql']
+        >>> print(s('up.rb', 'up.py')) # check extension sorting
+        ['up.py', 'up.rb']
+    '''
+    fn, ext = os.path.splitext(fn)
+    return [int(s) if s.isdigit() else s for s in NUM_RE.split(fn)], ext
 
 
 def loadpath(path):
@@ -86,8 +88,8 @@ def clean_sql(sql):
     return '\n'.join(x for x in sql.split('\n')
                      if not x.strip().startswith('--'))
 
-### URL retrievers
 
+# URL retrievers
 def get_python(path):
     pypath, attr = path.split(':')
     if '/' in pypath or pypath.endswith('.py'):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,6 @@
 SQLAlchemy==1.0.3
 cram==0.6
 PyYAML==3.11
+jinja2
 
 -e .

--- a/tests/basic.t
+++ b/tests/basic.t
@@ -12,6 +12,8 @@ First, set up environment::
   > [nomad]
   > engine = sqla
   > url = sqlite:///test.db
+  > [foo]
+  > bar = zeta
   > EOF
 
 First, initialize migrations repository::
@@ -88,3 +90,18 @@ It's possible to insert % into a db::
     sql migration applied: up.sql
   $ sqlite3 test.db 'select * from test'
   test%
+
+Using configuration templates
+  $ $NOMAD create 13-fourteen
+  $ mv 13-fourteen/up.sql 13-fourteen/up.sql.j2
+  $ echo "create table {{ foo.bar }} (value varchar(10));" > 13-fourteen/up.sql.j2
+  $ $NOMAD create 14-fifteen
+  $ mv 14-fifteen/up.sql 14-fifteen/up.sql.j2
+  $ echo "insert into {{ foo.bar }} values ('test');" >> 14-fifteen/up.sql.j2
+  $ $NOMAD apply -a
+  applying migration 13-fourteen:
+    sql template migration applied: up.sql.j2
+  applying migration 14-fifteen:
+    sql template migration applied: up.sql.j2
+  $ sqlite3 test.db 'select value from zeta'
+  test

--- a/tests/urls.t
+++ b/tests/urls.t
@@ -139,7 +139,7 @@ Nothing defined::
 
   $ echo '[nomad]\nengine=sqla' > nomad.ini
   $ $NOMAD info
-  \x1b[31mError: database url in <Repository: .> is not found\x1b[0m (esc)
+  \x1b[31mError: database url was not found in the nomad Configuration\x1b[0m (esc)
   [1]
 
 MultiURL::


### PR DESCRIPTION
The PR addresses three main things:

1.  Basic PEP8 cleanup
2.  Add support for Jinja2 templates via tha `.j2` extension.
3.  Provide all configuration options from `nomad.ini` and `migration.ini` to each jinja template (as a dict) and executables (as env variables)