### PR TITLE
Allow nomad to work on sqlserver

### DIFF
--- a/nomad/engine/__init__.py
+++ b/nomad/engine/__init__.py
@@ -5,7 +5,7 @@ class BaseEngine(object):
         self.url = url
 
     def __repr__(self):
-        return '<%s: %s>' % (type(self).__name__, self.url)
+        return "<%s: %s>" % (type(self).__name__, self.url)
 
     @property
     def connection(self):
@@ -33,16 +33,21 @@ class BaseEngine(object):
 
     @property
     def datetime_type(self):
-        if self.url.startswith('pgsql') or self.url.startswith('postgresql'):
-            return 'timestamp'
-        return 'datetime'
+        if self.url.startswith("pgsql") or self.url.startswith("postgresql"):
+            return "timestamp"
+        if self.url.startswith("mssql+pyodbc") or self.url.startswith("pyodbc"):
+            return "datetime2"
+        return "datetime"
 
     def init(self, tablename):
-        self.query('''CREATE TABLE %s (
+        self.query(
+            """CREATE TABLE %s (
             name varchar(255) NOT NULL,
             date %s NOT NULL
-        )''' % (tablename, self.datetime_type))
+        )"""
+            % (tablename, self.datetime_type)
+        )
 
 
 class DBError(Exception):
-    '''Database exception in nomad'''
+    """Database exception in nomad"""


### PR DESCRIPTION
- Sqlserver has a `datetime2` field that is different from `datetime`.
- To be able to add the nomad table and insert into it we should use this otherwise we get an error
```
Error: cannot apply migration 0-initial: (pyodbc.DataError) ('22007', '[22007] [Microsoft][ODBC Driver 18 for SQL Server][SQL Server]Conversion failed when converting date and/or time from ch
aracter string. (241) (SQLExecDirectW)')
[SQL: INSERT INTO nomad (name, date) VALUES (?, ?)]
[parameters: ('0-initial', '2022-11-18 15:36:23.626281')]  
```