### PR TITLE
Massive speed up for `apply -a` for a large number of migrations.

### DIFF
--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -139,7 +139,8 @@ def apply(all=('a', False, 'apply all available migrations'),
     if names:
         migrations = [repo.get(x) for x in names]
     elif all:
-        migrations = [x for x in repo.available if x not in repo.applied]
+        applied = set(repo.applied)
+        migrations = [x for x in repo.available if x not in applied]
     else:
         abort('Supply names of migrations to apply')
 


### PR DESCRIPTION
Avoid O(n^2) within `apply -a`. For 500+ migrations it sped up from `nomad apply -a` from 7.5 s to 0.17.