### PR TITLE
improve nomad ls performance

### DIFF
--- a/nomad/__init__.py
+++ b/nomad/__init__.py
@@ -68,18 +68,20 @@ def list_(all=('a', False, 'show all migrations (default: only non-applied)'),
     '''List migrations
     '''
     repo = opts['repo']
-    all_migrations = repo.available + [m for m in repo.applied
-                                       if m not in repo.available]
+    available = set(repo.available)
+    applied = set(repo.applied)
+    # must print in order, so can't just union both sets
+    all_migrations = repo.available + [m for m in repo.applied if m not in available]
     for m in all_migrations:
-        if m not in repo.available:
+        if m not in available:
             print(colored(m, 'red') + ' (not on disk)')
-        elif m in repo.applied:
+        elif m in applied:
             if all:
                 cprint(m, 'magenta')
         else:
             out = colored(str(m), 'green')
             deps = ', '.join(str(dep) for dep in m.dependencies
-                             if dep not in repo.applied)
+                             if dep not in applied)
             if deps:
                 out += ' (%s)' % deps
             print(out)


### PR DESCRIPTION
```
› ls | wc -l
     762
```

before
```
› time nomad ls
nomad ls  8.45s user 6.72s system 99% cpu 15.276 total
```

after
```
› time nomad ls
nomad ls  0.10s user 0.05s system 66% cpu 0.223 total
```