### PR TITLE
SQLAlchemy 2.0 compatibility

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.11', '3.12']
+        python-version: ['3.8', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
  Nomad Changelog
 =================
 
+2.5
+---
+
+- Support for SQLAlchemy 2.0+
+
 2.4
 ---
 

--- a/nomad/engine/sqla.py
+++ b/nomad/engine/sqla.py
@@ -1,27 +1,44 @@
-from sqlalchemy import create_engine, exc
+import re
+
+from sqlalchemy import create_engine, exc, text, __version__ as sqla_version
 
 from nomad.engine import BaseEngine, DBError
 
 
 class SAEngine(BaseEngine):
     def connect(self):
-        return create_engine(self.url)
+        engine = create_engine(self.url)
+        return engine.connect()
 
-    def prepare(self, statement, escape):
-        if self.connection.name in ('mysql', 'pgsql', 'postgresql'):
-            if escape:
-                return statement.replace('%', '%%')
-            return statement.replace('?', '%s')
-        return statement
+    def prepare(self, statement, args, escape):
+        # Get dialect name from connection's engine
+        dialect_name = self.connection.engine.dialect.name
+        if escape and dialect_name in ('mysql', 'pgsql', 'postgresql'):
+            return text(statement.replace('%', '%%'))
+
+        i = -1
+        def replacer(old):
+            nonlocal i
+            i += 1
+            return f':p{i}'
+
+        # SQLAlchemy 2.0 always wants named params in text statements
+        statement = re.sub(r'\?', replacer, statement)
+        params = {f'p{i}': arg for i, arg in enumerate(args)}
+        return text(statement).bindparams(**params)
 
     def query(self, statement, *args, **kwargs):
-        statement = self.prepare(statement, kwargs.pop('escape', False))
+        statement = self.prepare(statement, args, escape=kwargs.pop('escape', False))
         try:
-            return self.connection.execute(statement, *args, **kwargs)
+            return self.connection.execute(statement, **kwargs)
         except exc.SQLAlchemyError as e:
             raise DBError(str(e))
 
     begin = rollback = commit = lambda self: None
+
+    if sqla_version > '2':
+        def commit(self):
+            self.connection.commit()
 
     def nobegin(self):
         """TODO:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,12 +20,12 @@ classifiers = [
     'Topic :: Software Development :: Version Control',
     'Topic :: Database',
 ]
-dependencies = ['opster==5.0', 'termcolor==2.2.0']
+dependencies = ['opster==5.0', 'termcolor==3.2.0']
 optional-dependencies.test = [
-    'SQLAlchemy==1.4.52',
+    'SQLAlchemy==1.4.54',
     'prysk==0.20.0',
-    'PyYAML==6.0.1',
-    'jinja2==3.1.4',
+    'PyYAML==6.0.3',
+    'jinja2==3.1.6',
 ]
 
 [project.scripts]


### PR DESCRIPTION
I don't know if it's possible to automatically test against two different versions of SQLAlchemy. I've manually changed `pyproject.toml` to `SQLAlchemy==2.0.44` and error URL in `catch_error.t` to `sqlalche.me/e/20/e3q8`.

I didn't want to make a breaking change and drop SQLAlchemy 1.4 completely, when it's not hard to support both for now, and 1.4 is still maintained, AFAIK.

Not sure I've found the best approach to preparing statements.

Python 3.8 reached its end of life on October 7, 2024, and termcolor has already stopped supporting it, so I removed it.

3.14 has already been released, haven't tried to add it as well